### PR TITLE
Fix problems with slashes and non-unicode symbols in title

### DIFF
--- a/bin/backup-all-my-flickr-photos
+++ b/bin/backup-all-my-flickr-photos
@@ -12,7 +12,6 @@ import urllib
 import subprocess
 import argparse
 import json
-import re
 
 def main():
     parser = argparse.ArgumentParser(description="Download all your photos and videos on Flickr")

--- a/bin/backup-all-my-flickr-photos
+++ b/bin/backup-all-my-flickr-photos
@@ -12,6 +12,7 @@ import urllib
 import subprocess
 import argparse
 import json
+import re
 
 def main():
     parser = argparse.ArgumentParser(description="Download all your photos and videos on Flickr")
@@ -125,7 +126,8 @@ def download_item(photo, download_dir):
     extensions = ["jpg", "mov", "mp4"]
 
     if photo.title:
-        destname = "%s %s" % (photo.title, photo.id)
+        title = photo.title.replace('/', '')  # Remove slashes from the title
+        destname = "%s %s" % (title, photo.id)
     else:
         destname = "%s" % (photo.id, )
 

--- a/bin/backup-all-my-flickr-photos
+++ b/bin/backup-all-my-flickr-photos
@@ -15,7 +15,7 @@ import json
 
 def main():
     parser = argparse.ArgumentParser(description="Download all your photos and videos on Flickr")
-    parser.add_argument('destination_directory', metavar='d', help='Destination directory')
+    parser.add_argument('destination_directory', metavar='d', type=unicode, help='Destination directory')
     parser.add_argument('--delete', action='store_true', help="Delete files in destination directory that don't have corresponding items in the Flickr account")
     args = parser.parse_args()
     download_dir = args.destination_directory

--- a/bin/backup-all-my-flickr-photos
+++ b/bin/backup-all-my-flickr-photos
@@ -125,7 +125,7 @@ def download_item(photo, download_dir):
     extensions = ["jpg", "mov", "mp4"]
 
     if photo.title:
-        title = photo.title.replace('/', '')  # Remove slashes from the title
+        title = photo.title.replace(os.sep, '')  # Remove slashes from the title
         destname = "%s %s" % (title, photo.id)
     else:
         destname = "%s" % (photo.id, )


### PR DESCRIPTION
Removes slashes ("/") from photo title before use it as a part of destination filename. If filename contains slash than shutil.move raises IOError "No such file or directory" because slash-separation means directory-file hierarchy in Unix.
