### PR TITLE
Fix "Content-disposition" KeyError

### DIFF
--- a/bin/backup-all-my-flickr-photos
+++ b/bin/backup-all-my-flickr-photos
@@ -191,7 +191,7 @@ def guess_extension(url, headers):
     for extension in _extensions:
         if url.lower().endswith("." + extension):
             return extension
-    if headers['Content-Disposition']:
+    if 'Content-Disposition' in headers:
         value, params = cgi.parse_header(headers['Content-Disposition'])
         if value == 'attachment' and 'filename' in params:
             _, dot_extension = os.path.splitext(params['filename'])


### PR DESCRIPTION
If we go to download a file of a weird type (e.g. a very short movie) and cannot find a "Content-Disposition:" header, we may throw a "KeyError: Content-Disposition".

What we wanted to do was raise a "cannot guess extension" exception and print the URL. We can do that by checking whether the header exists rather than checking whether the value of the header is true.