### PR TITLE
Add --albums argument

### DIFF
--- a/bin/backup-all-my-flickr-photos
+++ b/bin/backup-all-my-flickr-photos
@@ -23,6 +23,7 @@ _extensions = ["jpg", "mov", "mp4", "png", "flv", "gif"]
 if not hasattr(flickr_api.Walker, '__next__'):
     flickr_api.Walker.__next__ = flickr_api.Walker.next
 
+
 def main():
     parser = argparse.ArgumentParser(description="Download all your photos and videos on Flickr")
     parser.add_argument('destination_directory', metavar='d', type=six.text_type, help='Destination directory')
@@ -52,6 +53,7 @@ def main():
     if args.delete:
         clean_stale_files(files_in_flickr, download_dir)
 
+
 def set_up_account_permissions():
     config_directory = get_config_directory()
     auth_filename = os.path.join(config_directory, "account_auth")
@@ -76,12 +78,14 @@ def set_up_account_permissions():
         auth_handler.save(auth_filename)
         print("Authorization saved to %s" % (auth_filename,))
 
+
 def get_config_directory():
     home_directory = os.getenv("HOME", os.path.expanduser("~"))
     return os.path.join(
         os.getenv("XDG_CONFIG_HOME", os.path.join(home_directory, ".config")),
         "backup-all-my-flickr-photos",
     )
+
 
 def set_up_flickr_keys():
     config_directory = get_config_directory()
@@ -170,6 +174,7 @@ def download_item(photo, download_dir):
 
 def download_file(photo, filename):
     url = photo.getPhotoFile(preferred_size(photo))
+
     def report(count_of_block, block_size, total_size):
         # print(count_of_block, block_size, total_size)
         percentage = (count_of_block * block_size * 100 ) / total_size

--- a/bin/backup-all-my-flickr-photos
+++ b/bin/backup-all-my-flickr-photos
@@ -53,7 +53,7 @@ def main():
         filename = download_item(photo, download_dir)
         if args.albums:
             dirs_in_flickr.update(add_to_albums(photo, filename, download_dir))
-        files_in_flickr.add(os.path.realpath(filename))
+        files_in_flickr.add(os.path.abspath(filename))
 
     if args.delete:
         clean_stale_files(files_in_flickr, download_dir)
@@ -265,7 +265,7 @@ def add_to_albums(photo, filename, download_dir):
 def clean_stale_files(files_in_flickr, download_dir):
     count_deleted = 0
     for filename in os.listdir(download_dir):
-        path = os.path.realpath(os.path.join(download_dir, filename))
+        path = os.path.abspath(os.path.join(download_dir, filename))
         if path not in files_in_flickr:
             print("Deleting %s" % path)
             os.remove(path)

--- a/bin/backup-all-my-flickr-photos
+++ b/bin/backup-all-my-flickr-photos
@@ -2,17 +2,17 @@
 
 from __future__ import absolute_import, division, print_function
 
+import argparse
+import cgi
+import errno
+import json
+import os
+import shutil
+import socket
+import sys
+
 import flickr_api
 import humanfriendly
-
-import os
-import sys
-import shutil
-import argparse
-import json
-import cgi
-import socket
-import errno
 import six
 from six.moves import urllib, reduce, input
 

--- a/bin/backup-all-my-flickr-photos
+++ b/bin/backup-all-my-flickr-photos
@@ -54,6 +54,29 @@ def main():
         clean_stale_files(files_in_flickr, download_dir)
 
 
+def automatic_retry(function):
+    @functools.wraps(function)
+    def wrapper(*args, **kwargs):
+        retries = 0
+        while retries < 10:
+            try:
+                return function(*args, **kwargs)
+            except (urllib.error.URLError, urllib.error.ContentTooShortError) as ee:
+                retries += 1
+                print("%r, retrying (%d)" % (ee, retries))
+            except socket.error as ee:
+                if ee.errno == errno.ECONNRESET:
+                    retries += 1
+                    print("socket.error Connection reset by peer, retrying (%d)" % retries)
+                else:
+                    print("Unrecognized socket error", file=sys.stderr)
+                    raise
+        print("Reached number of retries: %d" % (retries,))
+        return function(*args, **kwargs)
+
+    return wrapper
+
+
 def set_up_account_permissions():
     config_directory = get_config_directory()
     auth_filename = os.path.join(config_directory, "account_auth")
@@ -145,6 +168,7 @@ def set_up_flickr_keys():
         print("API key and secret saved to %s" % (keys_filename,))
 
 
+@automatic_retry
 def download_item(photo, download_dir):
     if photo.title:
         title = reduce( lambda s,char: s.replace(char,''), _forbidden_characters, photo.title)
@@ -224,25 +248,6 @@ def clean_stale_files(files_in_flickr, download_dir):
             os.remove(path)
             count_deleted += 1
     print("Deleted %d files." % count_deleted)
-
-
-def automatic_retry(function):
-    retries = 0
-    while retries < 10:
-        try:
-            return function()
-        except (urllib.error.URLError, urllib.error.ContentTooShortError) as ee:
-            retries += 1
-            print("%r, retrying (%d)" % (ee, retries))
-        except socket.error as ee:
-            if ee.errno == errno.ECONNRESET:
-                retries += 1
-                print("socket.error Connection reset by peer, retrying (%d)" % retries)
-            else:
-                print("Unrecognized socket error", file=sys.stderr)
-                raise
-    print("Reached number of retries: %d" % (retries,))
-    return function()
 
 
 if __name__ == "__main__":

--- a/bin/backup-all-my-flickr-photos
+++ b/bin/backup-all-my-flickr-photos
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function
 import argparse
 import cgi
 import errno
+import functools
 import json
 import os
 import shutil
@@ -28,6 +29,7 @@ def main():
     parser = argparse.ArgumentParser(description="Download all your photos and videos on Flickr")
     parser.add_argument('destination_directory', metavar='d', type=six.text_type, help='Destination directory')
     parser.add_argument('--delete', action='store_true', help="Delete files in destination directory that don't have corresponding items in the Flickr account")
+    parser.add_argument('--albums', action='store_true', help='Create album directories and symlink photos there')
     args = parser.parse_args()
     download_dir = args.destination_directory
 
@@ -42,12 +44,15 @@ def main():
     total_photos = user.getPhotos().info.total
     walker = flickr_api.Walker(user.getPhotos)
     files_in_flickr = set()
+    dirs_in_flickr = set()
 
     i = 0
     for photo in walker:
         i += 1
         print("Item %04d/%04d entitled %s" % (i, total_photos, photo.title))
-        filename = automatic_retry(lambda: download_item(photo, download_dir))
+        filename = download_item(photo, download_dir)
+        if args.albums:
+            dirs_in_flickr.update(add_to_albums(photo, filename, download_dir))
         files_in_flickr.add(os.path.realpath(filename))
 
     if args.delete:
@@ -168,13 +173,16 @@ def set_up_flickr_keys():
         print("API key and secret saved to %s" % (keys_filename,))
 
 
+def destination(obj):
+    if obj.title:
+        title = reduce(lambda s, char: s.replace(char, ''), _forbidden_characters, obj.title)
+        return "%s %s" % (title, obj.id)
+    return "%s" % (obj.id,)
+
+
 @automatic_retry
 def download_item(photo, download_dir):
-    if photo.title:
-        title = reduce( lambda s,char: s.replace(char,''), _forbidden_characters, photo.title)
-        destname = "%s %s" % (title, photo.id)
-    else:
-        destname = "%s" % (photo.id, )
+    destname = destination(photo)
 
     def path(extension):
         return os.path.join(download_dir, "%s%s" % (destname, extension))
@@ -237,6 +245,21 @@ def guess_extension(url, headers):
     # It's tempting to look at the Content-Type header here, but in the real
     # world, Flickr sets the wrong value for .mov files. So give up instead.
     raise(Exception("Cannot guess extension for URL %s" % (url,)))
+
+
+def add_to_albums(photo, filename, download_dir):
+    albums, _groups = automatic_retry(photo.getAllContexts)()
+    album_dirs = [os.path.join(download_dir, destination(album)) for album in albums]
+    basename = os.path.basename(filename)
+    for dirname in album_dirs:
+        linkname = os.path.join(dirname, basename)
+        if os.path.exists(linkname):
+            continue
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
+        relpath = os.path.relpath(filename, dirname)
+        os.symlink(relpath, linkname)
+    return album_dirs
 
 
 def clean_stale_files(files_in_flickr, download_dir):

--- a/bin/backup-all-my-flickr-photos
+++ b/bin/backup-all-my-flickr-photos
@@ -52,11 +52,13 @@ def main():
         print("Item %04d/%04d entitled %s" % (i, total_photos, photo.title))
         filename = download_item(photo, download_dir)
         if args.albums:
-            dirs_in_flickr.update(add_to_albums(photo, filename, download_dir))
+            files, dirs = add_to_albums(photo, filename, download_dir)
+            files_in_flickr.update(files)
+            dirs_in_flickr.update(dirs)
         files_in_flickr.add(os.path.abspath(filename))
 
     if args.delete:
-        clean_stale_files(files_in_flickr, download_dir)
+        clean_stale_files(files_in_flickr, dirs_in_flickr, download_dir)
 
 
 def automatic_retry(function):
@@ -251,28 +253,47 @@ def guess_extension(url, headers):
 
 def add_to_albums(photo, filename, download_dir):
     albums, _groups = automatic_retry(photo.getAllContexts)()
-    album_dirs = [os.path.join(download_dir, destination(album)) for album in albums]
+    dirs = [os.path.join(download_dir, destination(album)) for album in albums]
+    filenames = []
     basename = os.path.basename(filename)
-    for dirname in album_dirs:
+    for dirname in dirs:
         linkname = os.path.join(dirname, basename)
+        filenames.append(linkname)
         if os.path.exists(linkname):
             continue
         if not os.path.exists(dirname):
             os.makedirs(dirname)
         relpath = os.path.relpath(filename, dirname)
         os.symlink(relpath, linkname)
-    return album_dirs
+    return filenames, dirs
 
 
-def clean_stale_files(files_in_flickr, download_dir):
-    count_deleted = 0
-    for filename in os.listdir(download_dir):
-        path = os.path.abspath(os.path.join(download_dir, filename))
-        if path not in files_in_flickr:
-            print("Deleting %s" % path)
-            os.remove(path)
-            count_deleted += 1
-    print("Deleted %d files." % count_deleted)
+def clean_stale_files(files_in_flickr, dirs_in_flickr, download_dir):
+    count_files_deleted = 0
+    count_dirs_deleted = 0
+    for root, dirs, files in os.walk(download_dir):
+        dirs_to_walk_further = []
+        for d in dirs:
+            if d.startswith('.'):
+                continue
+            path = os.path.join(root, d)
+            if path not in dirs_in_flickr:
+                print("Deleting directory %s" % path)
+                shutil.rmtree(path)
+                count_dirs_deleted += 1
+            else:
+                dirs_to_walk_further.append(d)
+        dirs[:] = dirs_to_walk_further
+
+        for f in files:
+            if f.startswith('.'):
+                continue
+            path = os.path.join(root, f)
+            if path not in files_in_flickr:
+                print("Deleting file %s" % path)
+                os.remove(path)
+                count_files_deleted += 1
+    print("Deleted %d files and %d directories" % (count_files_deleted, count_dirs_deleted))
 
 
 if __name__ == "__main__":

--- a/bin/backup-all-my-flickr-photos
+++ b/bin/backup-all-my-flickr-photos
@@ -17,7 +17,7 @@ import six
 from six.moves import urllib, reduce, input
 
 _forbidden_characters = r'<>:"/\|?*'
-_extensions = ["jpg", "mov", "mp4", "png", "flv", "gif"]
+_extensions = [".jpg", ".mov", ".mp4", ".png", ".flv", ".gif"]
 
 # monkey patch to fix bug in Walker
 if not hasattr(flickr_api.Walker, '__next__'):
@@ -152,22 +152,26 @@ def download_item(photo, download_dir):
     else:
         destname = "%s" % (photo.id, )
 
-    file_exists = lambda: any([os.path.exists(os.path.join(download_dir, "%s.%s" % (destname, x))) for x in _extensions])
+    def path(extension):
+        return os.path.join(download_dir, "%s%s" % (destname, extension))
 
-    if not file_exists():
+    file_exists = any(os.path.exists(path(extension)) for extension in _extensions)
+    if not file_exists:
         try:
-            url, headers = download_file(photo, os.path.join(download_dir, "tmp"))
+            tmp_path = os.path.join(download_dir, "tmp")
+            url, headers = download_file(photo, tmp_path)
             extension = guess_extension(url, headers)
-            to = os.path.join(download_dir, "%s.%s" % (destname, extension))
+            to = path(extension)
             shutil.move(os.path.join(download_dir, "tmp"), to)
             print("Done: %s" % (to,))
         finally:
-            if os.path.exists(os.path.join(download_dir, "tmp")):
-                os.remove(os.path.join(download_dir, "tmp"))
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
 
     for extension in _extensions:
-        if os.path.exists(os.path.join(download_dir, "%s.%s" % (destname, extension))):
-            return os.path.join(download_dir, "%s.%s" % (destname, extension))
+        path_guess = path(extension)
+        if os.path.exists(path_guess):
+            return path_guess
 
     raise(Exception("Expected to find file %s.EXTENSION" % (destname,)))
 
@@ -197,14 +201,13 @@ def preferred_size(photo):
 
 
 def guess_extension(url, headers):
-    for extension in _extensions:
-        if url.lower().endswith("." + extension):
-            return extension
+    extension = os.path.splitext(url)[1].lower()
+    if extension in _extensions:
+        return extension
     if headers.get('Content-Disposition'):
         value, params = cgi.parse_header(headers['Content-Disposition'])
         if value == 'attachment' and 'filename' in params:
-            _, dot_extension = os.path.splitext(params['filename'])
-            extension = dot_extension[1:].lower()
+            extension = os.path.splitext(params['filename'])[1].lower()
             if extension in _extensions:
                 return extension
     # It's tempting to look at the Content-Type header here, but in the real

--- a/bin/backup-all-my-flickr-photos
+++ b/bin/backup-all-my-flickr-photos
@@ -176,6 +176,8 @@ def set_up_flickr_keys():
 def destination(obj):
     if obj.title:
         title = reduce(lambda s, char: s.replace(char, ''), _forbidden_characters, obj.title)
+        if title.startswith('.'):
+            title = ' %s' % title
         return "%s %s" % (title, obj.id)
     return "%s" % (obj.id,)
 

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ setup(
     scripts=['bin/backup-all-my-flickr-photos'],
     install_requires=[
         'flickr_api',
-        'future',
         'humanfriendly',
+        'six',
     ],
     license='bsd',
     project_urls={


### PR DESCRIPTION
Added `--albums` argument to make possible to backup albums. Album directories are created in the destination and soft links to photos are made inside them.

As I know, soft links don’t work on modern Windows without some system configuration, I'd like to discuss how we can overcome it. Should I add argument `--copy` to copy files inside directories? Also we can try to implement copy-on-write behaviour on some file-systems, e.g. Apple's APFS.

Also some minor code refactoring and formatting is done here