### PR TITLE
Guess .mp4 extension from URL

### DIFF
--- a/bin/backup-all-my-flickr-photos
+++ b/bin/backup-all-my-flickr-photos
@@ -202,6 +202,8 @@ def guess_extension(url, headers):
             extension = dot_extension[1:].lower()
             if extension in _extensions:
                 return extension
+    if '/play/' in url.lower():
+        return 'mp4'
     # It's tempting to look at the Content-Type header here, but in the real
     # world, Flickr sets the wrong value for .mov files. So give up instead.
     raise(Exception("Cannot guess extension for URL %s" % (url,)))


### PR DESCRIPTION
Typically video original URLs look like 'https://flickr.com/.../play/...'
We can safely set .mp4 extension for .mov (QuickTime) file because they both are containers for MPEG-4 and all modern video players will play such miss-named files normally

It should be fixed if f5c7b38 is merged into `master`