### PR TITLE
fix default video extension

### DIFF
--- a/bin/backup-all-my-flickr-photos
+++ b/bin/backup-all-my-flickr-photos
@@ -252,7 +252,7 @@ def guess_extension(url, headers):
             if extension in _extensions:
                 return extension
     if '/play/' in url.lower():
-        return 'mp4'
+        return '.mp4'
     # It's tempting to look at the Content-Type header here, but in the real
     # world, Flickr sets the wrong value for .mov files. So give up instead.
     raise(Exception("Cannot guess extension for URL %s" % (url,)))


### PR DESCRIPTION
otherwise the downloaded file didn't have dot before the extension and it wasn't being found

```Traceback (most recent call last):
  File "/Users//projects/.venv/bin/backup-all-my-flickr-photos", line 307, in <module>
    main()
  File "/Users//projects/.venv/bin/backup-all-my-flickr-photos", line 53, in main
    filename = download_item(photo, download_dir)
  File "/Users//projects/.venv/bin/backup-all-my-flickr-photos", line 75, in wrapper
    return function(*args, **kwargs)
  File "/Users//projects/.venv/bin/backup-all-my-flickr-photos", line 217, in download_item
    raise(Exception("Expected to find file %s.EXTENSION" % (destname,)))
Exception: Expected to find file VID_20191210_195718 FGHJFGHJ.EXTENSION```